### PR TITLE
chore: Pin GitHub Actions to SHA hashes and enhance security

### DIFF
--- a/.github/workflows/hello-world.yaml
+++ b/.github/workflows/hello-world.yaml
@@ -14,7 +14,9 @@ jobs:
           - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Hello World
         uses: ./
         with:

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -12,9 +12,10 @@ jobs:
       statuses: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: super-linter/super-linter@v7
         env:


### PR DESCRIPTION
## Summary
- Pin actions/checkout to v4.2.2 SHA hash for supply chain security
- Add persist-credentials: false to prevent credential leakage  
- Aligns with GitHub Actions security best practices from setup-action

## Changes
- 📌 Pin `actions/checkout@v4` to specific SHA with version comment
- 🔒 Add `persist-credentials: false` to all checkout steps
- Applies to both linter.yaml and hello-world.yaml workflows

## Why?
Pinning actions to SHA hashes prevents supply chain attacks where action tags could be moved to malicious code. Setting `persist-credentials: false` prevents accidental credential exposure in subsequent steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)