### PR TITLE
chore: Improve linter configuration and efficiency

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -16,7 +16,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: super-linter/super-linter@v7
+      - uses: super-linter/super-linter/slim@502f4fe48a81a392756e173e39a861f8c8efe056 # v8.3.0
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FILTER_REGEX_EXCLUDE: download_amber\.sh
-          GITHUB_TOKEN: secrets.GITHUB_TOKEN
+          VALIDATE_JSON_PRETTIER: false
+          VALIDATE_YAML_PRETTIER: false
+          VALIDATE_MARKDOWN_PRETTIER: false


### PR DESCRIPTION
## Summary
- Upgrade to super-linter/slim v8.3.0 for faster execution and smaller footprint
- Pin super-linter to SHA hash for security
- Fix GITHUB_TOKEN syntax to use proper GitHub Actions expression
- Disable prettier validation to reduce linting noise

## Changes
- 🚀 Use `super-linter/slim` instead of full version for efficiency
- 📌 Pin to v8.3.0 SHA hash
- 🔧 Fix `GITHUB_TOKEN: secrets.GITHUB_TOKEN` → `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}`
- ✨ Add `VALIDATE_*_PRETTIER: false` to disable prettier checks
- 📝 Reorder env vars for better readability (GITHUB_TOKEN first)

## Why?
The slim version of super-linter is more efficient and faster. The GITHUB_TOKEN syntax was incorrect and would not work properly. Prettier validation is disabled to match setup-action's configuration and reduce false positives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)