### PR TITLE
refactor: Convert bash scripts to amber-script-action

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -20,67 +20,69 @@ inputs:
 runs:
   using: composite
   steps:
-    - id: hash-script
-      shell: bash
-      env:
-        SCRIPT_CONTENT: ${{ inputs.script }}
-      run: |
-        # Make cache key for given script
-        # Note: macos runner does not have sha256sum.
-        {
-          echo -n 'hash='
-          printf '%s\n' "$SCRIPT_CONTENT" | openssl sha256 | cut -d' ' -f 2
-        } >> "$GITHUB_OUTPUT"
-    - shell: bash
-      env:
-        CACHE_PATH_INPUT: ${{ inputs.cache-path }}
-      run: |
-        # Export cache path
-        if [ -n "$CACHE_PATH_INPUT" ]; then
-          {
-            echo "amber_cache_path<<CACHE_PATH_EOF"
-            echo "$CACHE_PATH_INPUT"
-            echo "CACHE_PATH_EOF"
-          } >> "$GITHUB_ENV"
-        elif [ "${{ runner.os }}" == "Linux" ]; then
-          echo "amber_cache_path=/home/runner/.amber-script-action" >> "$GITHUB_ENV"
-        else
-          echo "amber_cache_path=/Users/runner/.amber-script-action" >> "$GITHUB_ENV"
-        fi
     - name: Cache compiled script
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       if: inputs.enable-cache
       with:
-        path: ${{ env.amber_cache_path }}/dest
+        path: ${{ inputs.cache-path != '' && format('{0}/dest', inputs.cache-path) || (runner.os == 'Linux' && '/home/runner/.amber-script-action/dest' || '/Users/runner/.amber-script-action/dest') }}
         key: amber-script-action-${{ runner.os }}-script-${{ inputs.amber-version }}
     - uses: lens0021/setup-amber@2e13727a77c839ecb407da90736cc07b8d68cd42 # v1.1.0
       with:
         amber-version: ${{ inputs.amber-version }}
         enable-cache: ${{ inputs.enable-cache }}
-        cache-path: ${{ env.amber_cache_path }}/actions/setup-amber
-        bin-path: ${{ env.amber_cache_path }}/bin/amber-${{ inputs.amber-version }}
-    # TODO: Convert this to amber-script-action.
-    # This includes a here-document expression, so hard to convert.
-    - shell: bash
+        cache-path: ${{ inputs.cache-path != '' && format('{0}/actions/setup-amber', inputs.cache-path) || (runner.os == 'Linux' && '/home/runner/.amber-script-action/actions/setup-amber' || '/Users/runner/.amber-script-action/actions/setup-amber') }}
+        bin-path: ${{ inputs.cache-path != '' && format('{0}/bin/amber-{1}', inputs.cache-path, inputs.amber-version) || (runner.os == 'Linux' && format('/home/runner/.amber-script-action/bin/amber-{0}', inputs.amber-version) || format('/Users/runner/.amber-script-action/bin/amber-{0}', inputs.amber-version)) }}
+    - name: Build and run script
+      uses: lens0021/amber-script-action@31ab14026ac16a3d93bc20767087084ce5344517 # v1.1.1
       env:
-        AMBER_CACHE_PATH: ${{ env.amber_cache_path }}
+        CACHE_PATH_INPUT: ${{ inputs.cache-path }}
+        RUNNER_OS: ${{ runner.os }}
         SCRIPT_CONTENT: ${{ inputs.script }}
         AMBER_VERSION: ${{ inputs.amber-version }}
-        SCRIPT_HASH: ${{ steps.hash-script.outputs.hash }}
-      run: |
-        # Build the given script
-        if [ -e "${AMBER_CACHE_PATH}/dest/${SCRIPT_HASH}.sh" ]; then
-          echo "::debug::A compiled bash script found. Skip building."
-        else
-          mkdir -p "${AMBER_CACHE_PATH}/tmp"
-          printf '%s\n' "$SCRIPT_CONTENT" > "${AMBER_CACHE_PATH}/tmp/${SCRIPT_HASH}.ab"
-          mkdir -p "${AMBER_CACHE_PATH}/dest"
-          "${AMBER_CACHE_PATH}/bin/amber-${AMBER_VERSION}" build "${AMBER_CACHE_PATH}/tmp/${SCRIPT_HASH}.ab" "${AMBER_CACHE_PATH}/dest/${SCRIPT_HASH}.sh"
-        fi
-    - shell: bash
-      env:
-        AMBER_CACHE_PATH: ${{ env.amber_cache_path }}
-        SCRIPT_HASH: ${{ steps.hash-script.outputs.hash }}
-      run: |
-        # Run the compiled script
-        bash "${AMBER_CACHE_PATH}/dest/${SCRIPT_HASH}.sh"
+      with:
+        amber-version: 0.5.0-alpha
+        script: |
+          import { trim } from "std/text"
+          import { env_var_get } from "std/env"
+          import { dir_create, file_exists, file_write } from "std/fs"
+
+          // Calculate cache path
+          const cache_path_input = trust env_var_get("CACHE_PATH_INPUT")
+          const runner_os = trust env_var_get("RUNNER_OS")
+          const amber_cache_path = trim(cache_path_input) != ""
+            then cache_path_input
+            else runner_os == "Linux"
+              then "/home/runner/.amber-script-action"
+              else "/Users/runner/.amber-script-action"
+
+          const script_content = trust env_var_get("SCRIPT_CONTENT")
+          const amber_version = trust env_var_get("AMBER_VERSION")
+
+          // Calculate hash for the given script
+          // Note: macos runner does not have sha256sum.
+          let script_hash = $ printf '%s\n' "{script_content}" | openssl sha256 | cut -d' ' -f 2 $ failed(code) {
+            echo "Failed to calculate script hash"
+            exit code
+          }
+
+          const dest_path = "{amber_cache_path}/dest/{script_hash}.sh"
+
+          // Build the given script
+          if file_exists(dest_path) {
+            echo "::debug::A compiled bash script found. Skip building."
+          } else {
+            trust dir_create("{amber_cache_path}/tmp")
+            trust file_write("{amber_cache_path}/tmp/{script_hash}.ab", script_content)
+            trust dir_create("{amber_cache_path}/dest")
+
+            $ "{amber_cache_path}/bin/amber-{amber_version}" build "{amber_cache_path}/tmp/{script_hash}.ab" "{dest_path}" $ failed(code) {
+              echo "Failed to build script with exit code {code}"
+              exit code
+            }
+          }
+
+          // Run the compiled script
+          $ bash "{dest_path}" $ failed(code) {
+            echo "Failed to run script with exit code {code}"
+            exit code
+          }


### PR DESCRIPTION
## Summary
- Replace bash scripts with `lens0021/amber-script-action@v1.1.1`
- Remove GITHUB_ENV usage by calculating cache paths directly using GitHub Actions expressions
- Combine hash calculation, build, and run steps into a single amber-script-action step
- Remove TODO comment about converting to amber-script-action

## Benefits
- More maintainable: Uses Amber's modern syntax with proper error handling
- Simpler: Eliminates GITHUB_ENV by calculating cache paths inline
- More efficient: Combines multiple steps into one, reducing overhead
- Consistent: Uses the same amber-script-action pattern as setup-amber

🤖 Generated with [Claude Code](https://claude.com/claude-code)