### PR TITLE
fix: Add AMBER_SCRIPT_ prefix to environment variables

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -35,10 +35,10 @@ runs:
     - name: Build and run script
       uses: lens0021/amber-script-action@31ab14026ac16a3d93bc20767087084ce5344517 # v1.1.1
       env:
-        CACHE_PATH_INPUT: ${{ inputs.cache-path }}
-        RUNNER_OS: ${{ runner.os }}
-        SCRIPT_CONTENT: ${{ inputs.script }}
-        AMBER_VERSION: ${{ inputs.amber-version }}
+        AMBER_SCRIPT_CACHE_PATH_INPUT: ${{ inputs.cache-path }}
+        AMBER_SCRIPT_RUNNER_OS: ${{ runner.os }}
+        AMBER_SCRIPT_CONTENT: ${{ inputs.script }}
+        AMBER_SCRIPT_VERSION: ${{ inputs.amber-version }}
       with:
         amber-version: 0.5.0-alpha
         script: |
@@ -47,16 +47,16 @@ runs:
           import { dir_create, file_exists, file_write } from "std/fs"
 
           // Calculate cache path
-          const cache_path_input = trust env_var_get("CACHE_PATH_INPUT")
-          const runner_os = trust env_var_get("RUNNER_OS")
+          const cache_path_input = trust env_var_get("AMBER_SCRIPT_CACHE_PATH_INPUT")
+          const runner_os = trust env_var_get("AMBER_SCRIPT_RUNNER_OS")
           const amber_cache_path = trim(cache_path_input) != ""
             then cache_path_input
             else runner_os == "Linux"
               then "/home/runner/.amber-script-action"
               else "/Users/runner/.amber-script-action"
 
-          const script_content = trust env_var_get("SCRIPT_CONTENT")
-          const amber_version = trust env_var_get("AMBER_VERSION")
+          const script_content = trust env_var_get("AMBER_SCRIPT_CONTENT")
+          const amber_version = trust env_var_get("AMBER_SCRIPT_VERSION")
 
           // Calculate hash for the given script
           // Note: macos runner does not have sha256sum.


### PR DESCRIPTION
## Summary

This PR adds an `AMBER_SCRIPT_` prefix to internal environment variables to prevent conflicts with external actions.

## Problem

When amber-script-action is used as a dependency by other actions (like setup-amber), environment variables like `AMBER_VERSION`, `RUNNER_OS`, etc. can conflict with the calling action's own environment variables.

## Solution

By using prefixed environment variable names:
- `CACHE_PATH_INPUT` → `AMBER_SCRIPT_CACHE_PATH_INPUT`
- `RUNNER_OS` → `AMBER_SCRIPT_RUNNER_OS`
- `SCRIPT_CONTENT` → `AMBER_SCRIPT_CONTENT`
- `AMBER_VERSION` → `AMBER_SCRIPT_VERSION`

We avoid collisions and ensure that amber-script-action's internal variables don't interfere with external actions.

## Related

This is the counterpart to lens0021/setup-amber-action#30, which adds `SETUP_AMBER_` prefixes.