### PR TITLE
docs(changelog): Fix section title to 'Bugfixes'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,6 @@
 * Update default amber-version to 0.5.1-alpha ([#48](https://github.com/lens0021/amber-script-action/issues/48)) ([c792ee1](https://github.com/lens0021/amber-script-action/commit/c792ee1d8ce19037c28108f03c5c03d968c710fd))
 
 
-### Bug Fixes
+### Bugfixes
 
 * Address security vulnerabilities found by zizmor ([#41](https://github.com/lens0021/amber-script-action/issues/41)) ([bedb067](https://github.com/lens0021/amber-script-action/commit/bedb067ed45201913354a07a00660c2cce15f8af))


### PR DESCRIPTION
## Summary

This PR fixes the CHANGELOG section title from "Bug Fixes" to "Bugfixes" to match the current release-please configuration.

## Background

PR #38 (v2.0.0 release) was generated by release-please before PR #46 updated the configuration to use "Bugfixes" instead of "Bug Fixes". Since the fix commit (#41) was already processed with the old configuration, it was recorded with the old section title.

## Changes

- Change "Bug Fixes" → "Bugfixes" in CHANGELOG.md

## Prevention

Future releases will automatically use "Bugfixes" since the release-please configuration was updated in PR #46. This is a one-time manual fix for the historical v2.0.0 release.