### PR TITLE
refactor(cache): Use XDG-compliant cache directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,8 @@ See [action.yaml](action.yaml)
     enable-cache: ""
 
     # The path to store Amber binaries and the compiled bash scripts.
-    # If empty string is given, the used path depends on the runner.
-    # Default (Linux): '/home/runner/.amber-script-action'
-    # Default (Mac): '/Users/runner/.amber-script-action'
+    # If empty string is given, the default path will be used.
+    # Default: '~/.cache/amber-script-action'
     cache-path: ""
 ```
 

--- a/action.yaml
+++ b/action.yaml
@@ -24,18 +24,17 @@ runs:
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       if: inputs.enable-cache
       with:
-        path: ${{ inputs.cache-path != '' && format('{0}/dist', inputs.cache-path) || (runner.os == 'Linux' && '/home/runner/.amber-script-action/dist' || '/Users/runner/.amber-script-action/dist') }}
+        path: ${{ inputs.cache-path != '' && format('{0}/dist', inputs.cache-path) || '~/.cache/amber-script-action/dist' }}
         key: amber-script-action-${{ runner.os }}-script-${{ inputs.amber-version }}
     - uses: lens0021/setup-amber@014375f0b64132ead405709f11653f95c6aa1652 # v2.0.0
       with:
         amber-version: ${{ inputs.amber-version }}
         enable-cache: ${{ inputs.enable-cache }}
-        cache-path: ${{ inputs.cache-path != '' && format('{0}/actions/setup-amber', inputs.cache-path) || (runner.os == 'Linux' && '/home/runner/.amber-script-action/actions/setup-amber' || '/Users/runner/.amber-script-action/actions/setup-amber') }}
-        bin-path: ${{ inputs.cache-path != '' && format('{0}/bin/amber-{1}', inputs.cache-path, inputs.amber-version) || (runner.os == 'Linux' && format('/home/runner/.amber-script-action/bin/amber-{0}', inputs.amber-version) || format('/Users/runner/.amber-script-action/bin/amber-{0}', inputs.amber-version)) }}
+        cache-path: ${{ inputs.cache-path != '' && format('{0}/actions/setup-amber', inputs.cache-path) || '~/.cache/amber-script-action/actions/setup-amber' }}
+        bin-path: ${{ inputs.cache-path != '' && format('{0}/bin/amber-{1}', inputs.cache-path, inputs.amber-version) || format('~/.cache/amber-script-action/bin/amber-{0}', inputs.amber-version) }}
     - shell: bash
       env:
         AMBER_SCRIPT_CACHE_PATH_INPUT: ${{ inputs.cache-path }}
-        AMBER_SCRIPT_RUNNER_OS: ${{ runner.os }}
         AMBER_SCRIPT_CONTENT: ${{ inputs.script }}
         AMBER_SCRIPT_VERSION: ${{ inputs.amber-version }}
       run: |

--- a/dist/main.sh
+++ b/dist/main.sh
@@ -87,12 +87,12 @@ env_var_get__99_v0() {
 env_var_get__99_v0 "AMBER_SCRIPT_CACHE_PATH_INPUT"
 __status=$?
 cache_path_input_3="${ret_env_var_get99_v0}"
-env_var_get__99_v0 "AMBER_SCRIPT_RUNNER_OS"
+env_var_get__99_v0 "HOME"
 __status=$?
-runner_os_4="${ret_env_var_get99_v0}"
+home_4="${ret_env_var_get99_v0}"
 trim__11_v0 "${cache_path_input_3}"
 ret_trim11_v0__8_26="${ret_trim11_v0}"
-amber_cache_path_5="$(if [ "$([ "_${ret_trim11_v0__8_26}" == "_" ]; echo $?)" != 0 ]; then echo "${cache_path_input_3}"; else echo "$(if [ "$([ "_${runner_os_4}" != "_Linux" ]; echo $?)" != 0 ]; then echo "/home/runner/.amber-script-action"; else echo "/Users/runner/.amber-script-action"; fi)"; fi)"
+amber_cache_path_5="$(if [ "$([ "_${ret_trim11_v0__8_26}" == "_" ]; echo $?)" != 0 ]; then echo "${cache_path_input_3}"; else echo "${home_4}/.cache/amber-script-action"; fi)"
 env_var_get__99_v0 "AMBER_SCRIPT_CONTENT"
 __status=$?
 script_content_6="${ret_env_var_get99_v0}"
@@ -113,8 +113,8 @@ script_hash_9="${command_4}"
 dist_path_10="${amber_cache_path_5}/dist/${script_hash_9}.sh"
 # Build the given script
 file_exists__38_v0 "${dist_path_10}"
-ret_file_exists38_v0__27_4="${ret_file_exists38_v0}"
-if [ "${ret_file_exists38_v0__27_4}" != 0 ]; then
+ret_file_exists38_v0__25_4="${ret_file_exists38_v0}"
+if [ "${ret_file_exists38_v0__25_4}" != 0 ]; then
     echo "::debug::A compiled bash script found. Skip building."
 else
     dir_create__43_v0 "${amber_cache_path_5}/tmp"

--- a/src/main.ab
+++ b/src/main.ab
@@ -4,12 +4,10 @@ import { dir_create, file_exists, file_write } from "std/fs"
 
 // Calculate cache path
 const cache_path_input = trust env_var_get("AMBER_SCRIPT_CACHE_PATH_INPUT")
-const runner_os = trust env_var_get("AMBER_SCRIPT_RUNNER_OS")
+const home = trust env_var_get("HOME")
 const amber_cache_path = trim(cache_path_input) != ""
   then cache_path_input
-  else runner_os == "Linux"
-    then "/home/runner/.amber-script-action"
-    else "/Users/runner/.amber-script-action"
+  else "{home}/.cache/amber-script-action"
 
 const script_content = trust env_var_get("AMBER_SCRIPT_CONTENT")
 const amber_version = trust env_var_get("AMBER_SCRIPT_VERSION")


### PR DESCRIPTION
> - Use XDG Base Directory specification for cache path (`~/.cache/amber-script-action`)
> - Simplify cache path logic by removing OS-specific branches\
> 
> ## Changes
> 
> ### Cache Directory Migration
> - **Before**: `/home/runner/.amber-script-action` (Linux), `/Users/runner/.amber-script-action` (macOS)
> - **After**: `~/.cache/amber-script-action` (all platforms)
> 
> This change follows the [XDG Base Directory specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html), which is the standard used by most GitHub Actions caching implementations.
> 
> ### Benefits
> - Platform-independent cache path using `HOME` environment variable
> - Consistent with GitHub Actions ecosystem best practices
> - Cleaner, more maintainable code without OS-specific branches
> 
> ### Migration Notes
> Users relying on the default cache path will see their cache invalidated once. The action will automatically create and use the new cache location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)