### PR TITLE
fix: Propagate script exit code correctly

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -50,4 +50,4 @@ runs:
         AMBER_SCRIPT_HASH: ${{ steps.script-hash.outputs.hash }}
       run: |
         # Build and run script
-        bash "${{ github.action_path }}/dist/main.sh"
+        bash -e "${{ github.action_path }}/dist/main.sh"


### PR DESCRIPTION
> Fixed script exit code propagation by using `bash -e` option when running `dist/main.sh`
> 
> ## Problem
> Previously, even if the user's Amber script failed (e.g., `jq -r '.allVersions[-1]' config.json` returning non-zero exit code), the GitHub Actions step would still succeed. This happened because `dist/main.sh` always returned exit code 0 due to its last command being `__status=$?` (variable assignment always succeeds with exit code 0).
> 
> ## Solution
> By adding the `-e` option to the bash command, the script will exit immediately when any command fails. This prevents the `__status=$?` line from executing and allows the actual exit code to propagate correctly to the GitHub Actions workflow.
> 
> Changed line in action.yaml:
> ```diff
> -        bash "${{ github.action_path }}/dist/main.sh"
> +        bash -e "${{ github.action_path }}/dist/main.sh"
> ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
