### PR TITLE
revert: "fix: Propagate script exit code correctly (#81)"

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -52,4 +52,4 @@ runs:
         AMBER_SCRIPT_HASH: ${{ steps.script-hash.outputs.hash }}
       run: |
         # Build and run script
-        bash -e "${{ github.action_path }}/dist/main.sh"
+        bash "${{ github.action_path }}/dist/main.sh"


### PR DESCRIPTION
This reverts commit bedaba2bdd59a0474423d00d474c0d905d359855.

The compiled Amber does not appear to be ready to run with the `-e` option.